### PR TITLE
Fix terminal flushing by removing completion dots

### DIFF
--- a/source/zshrc
+++ b/source/zshrc
@@ -7,8 +7,6 @@ ZSH_THEME="kolo"
 
 ENABLE_CORRECTION="true"
 
-COMPLETION_WAITING_DOTS="true"
-
 ZSH_HIGHLIGHT_HIGHLIGHTERS=(main brackets pattern cursor root)
 
 DISABLE_UPDATE_PROMPT=true


### PR DESCRIPTION
[COMPLETION_WAITING_DOTS caused flushing issues](https://github.com/robbyrussell/oh-my-zsh/issues/5765) as of macOS High Sierra. Turning off for now.