### PR TITLE
Fix vim temporary file handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 source/vim/undo/
+source/vim/backup/
+source/vim/swap/
 source/vim/colors/
 source/vim/pack/kite/
 .netrwhist

--- a/source/vimrc
+++ b/source/vimrc
@@ -38,7 +38,7 @@ set tags=.tags;/
 
 " Undo {{{
 set undofile
-set undodir=~/.vim/undo
+set undodir=~/.vim/undo//
 " }}}
 
 " Text Width {{{
@@ -115,8 +115,9 @@ match ErrorMsg '\s\+$'
 " }}}
 
 " Temporary Files {{{
-set nobackup
-set noswapfile
+set backupcopy=yes
+set backupdir=~/.vim/backup//
+set directory=~/.vim/swap//
 " }}}
 
 " Line Recall {{{


### PR DESCRIPTION
* Reconfigure Vim to use backups and swaps to avoid crashes and editor session collisions
* `backupcopy=yes`: This stops Vim from updating the inode of a file when modified, which is useful for programs like Obsidian that use the file's `ctime` attribute to determine when a file was "created."