### PR TITLE
Add pipxfile for common pipx deps

### DIFF
--- a/source/pipxfile
+++ b/source/pipxfile
@@ -1,0 +1,16 @@
+black
+pyproject-build
+flake8
+llm
+mypy
+pip-tools
+pipx
+pre-commit
+pyupgrade
+radon
+shot-scraper
+sphinx
+strip-tags
+tox
+ttok
+twine


### PR DESCRIPTION
This can't directly be used by pipx; something like this:

```sh
$ for package in $(cat pipxfile); do
    pipx install $package;
done
```